### PR TITLE
Support gVisor, remove unneeded GCE check

### DIFF
--- a/steps/image-build/Dockerfile
+++ b/steps/image-build/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux ; \
     mv ni-v1*-linux-amd64 /usr/local/bin/ni && \
     cd - && \
     rm -fr /tmp/ni
-RUN apk --no-cache add bash ca-certificates curl git jq openssh socat && update-ca-certificates
+RUN apk --no-cache add bash ca-certificates curl git jq openssh && update-ca-certificates
 COPY --from=base /kaniko /kaniko
 RUN ["docker-credential-gcr", "config", "--token-source=env"]
 COPY ./step.sh /nebula/step.sh

--- a/steps/image-build/Dockerfile.tpl
+++ b/steps/image-build/Dockerfile.tpl
@@ -21,7 +21,7 @@ RUN set -eux ; \
     mv ni-{{ .SDKVersion }}*-linux-amd64 /usr/local/bin/ni && \
     cd - && \
     rm -fr /tmp/ni
-RUN apk --no-cache add bash ca-certificates curl git jq openssh socat && update-ca-certificates
+RUN apk --no-cache add bash ca-certificates curl git jq openssh && update-ca-certificates
 COPY --from=base /kaniko /kaniko
 RUN ["docker-credential-gcr", "config", "--token-source=env"]
 COPY ./step.sh /nebula/step.sh

--- a/steps/image-build/container.yaml
+++ b/steps/image-build/container.yaml
@@ -4,6 +4,7 @@ title: Kaniko
 description: >
   The Kaniko task runs the Kaniko image builder.
 sdkVersion: v1
+name: kaniko-step-image-build
 images:
   base:
     template: Dockerfile.tpl

--- a/steps/image-build/scripts/build-container
+++ b/steps/image-build/scripts/build-container
@@ -38,9 +38,9 @@ done
 shift $(( OPTIND - 1 ))
 
 
-$DOCKER $DOCKER_ARGS build $DOCKER_BUILD_ARGS --tag sdk.nebula.localhost/intermediate/f825a6225f16/kaniko --file Dockerfile .
+$DOCKER $DOCKER_ARGS build $DOCKER_BUILD_ARGS --tag sdk.nebula.localhost/intermediate/887bd60c7072/kaniko-step-image-build --file Dockerfile .
 
 for TAG in ${TAGS[@]+"${TAGS[@]}"}; do
-  $DOCKER $DOCKER_ARGS tag sdk.nebula.localhost/intermediate/f825a6225f16/kaniko "projectnebula/kaniko:${TAG}" && \
-    printf "# Tagged %s:%s\n" projectnebula/kaniko "${TAG}"
+  $DOCKER $DOCKER_ARGS tag sdk.nebula.localhost/intermediate/887bd60c7072/kaniko-step-image-build "relaysh/kaniko-step-image-build:${TAG}" && \
+    printf "# Tagged %s:%s\n" relaysh/kaniko-step-image-build "${TAG}"
 done

--- a/steps/image-build/step.sh
+++ b/steps/image-build/step.sh
@@ -16,28 +16,9 @@ declare -a BUILD_ARGS_OPTIONS="($(ni get | jq -r 'try .buildArgs | to_entries[] 
 CONTEXT="/workspace/${NAME}/${CONTEXT}"
 DOCKERFILE="${CONTEXT}/${DOCKERFILE:-Dockerfile}"
 
-# kaniko uses the DMI/SMBIOS information (indirectly via sysfs) to determine
-# whether we're running on GCE. Since cloud execution indeed happens on GCE, our
-# CRI (correctly?) propagates the GCE DMI information into the container.
-#
-# However, we firewall off access to the GCE metadata API. kaniko will then sit
-# in an infinite loop waiting for the metadata API to come up. Of course, our
-# uncompromising firewall will never let it succeed.
-#
-# Since we don't have a good way to inject our own DMI information yet, we
-# instead stub out a fake HTTP server that makes kaniko think the metadata
-# service is up.
-case "$( </sys/class/dmi/id/product_name )" in
-*Google*)
-  ni log warn 'Detected Google DMI configuration, installing workaround...'
-
-  socat tcp-listen:80,bind=127.0.0.111,crlf,reuseaddr,fork system:'echo "HTTP/1.1 200 OK"; echo "Connection: close"; echo;' &
-  cat >>/etc/hosts <<<$'\n127.0.0.111 metadata.google.internal\n'
-  ;;
-esac
-
 /kaniko/executor \
     ${BUILD_ARGS_OPTIONS[@]} \
     --dockerfile=${DOCKERFILE} \
     --context=${CONTEXT} \
-    --destination=${DESTINATION}
+    --destination=${DESTINATION} \
+    --force


### PR DESCRIPTION
Since we've moved to gVisor, we no longer need the check for GCE that forbids access to the metadata service, and since gVisor actually hides the fact that it's running in a container, we do need to add `--force`.